### PR TITLE
Add dynamic calendar view

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,6 +10,10 @@
   url: "/events/"
   side: left
 
+- title: Calendar
+  url: "/calendar/"
+  side: left
+
 - title: Volunteer
   url: "/volunteer/"
   side: left

--- a/_includes/_calendar.html
+++ b/_includes/_calendar.html
@@ -1,0 +1,180 @@
+{% comment %}
+Calendar view for events, rides, and volunteer opportunities.
+Uses post.date for calendar positioning and displays thumbnails.
+Shows upcoming events first, then past events.
+{% endcomment %}
+
+{% assign all_posts = site.categories.events | concat: site.categories.rides | concat: site.categories.volunteers %}
+{% assign sorted_posts = all_posts | sort: 'date' | reverse %}
+
+{% assign today = 'now' | date: '%Y-%m-%d' %}
+
+{% comment %} Separate upcoming and past posts {% endcomment %}
+{% assign upcoming_posts = "" | split: "" %}
+{% assign past_posts = "" | split: "" %}
+
+{% for post in sorted_posts %}
+  {% assign post_date = post.date | date: '%Y-%m-%d' %}
+  {% if post_date >= today %}
+    {% assign upcoming_posts = upcoming_posts | push: post %}
+  {% else %}
+    {% assign past_posts = past_posts | push: post %}
+  {% endif %}
+{% endfor %}
+
+{% assign upcoming_posts = upcoming_posts | reverse %}
+
+<div class="calendar-container">
+
+  {% comment %} Upcoming Events Section {% endcomment %}
+  {% if upcoming_posts.size > 0 %}
+    <h2 class="calendar-section-header">Upcoming</h2>
+
+    {% assign displayed_months = "" %}
+
+    {% for post in upcoming_posts %}
+      {% assign post_month_key = post.date | date: '%Y-%m' %}
+      {% assign post_day = post.date | date: '%-d' %}
+
+      {% comment %} Check if we need a new month header {% endcomment %}
+      {% unless displayed_months contains post_month_key %}
+        {% if displayed_months != "" %}
+          </div><!-- /.calendar-grid -->
+        {% endif %}
+
+        <h3 class="calendar-month-header">{{ post.date | date: '%B %Y' }}</h3>
+        <div class="calendar-grid">
+
+        {% capture displayed_months %}{{ displayed_months }}{{ post_month_key }},{% endcapture %}
+      {% endunless %}
+
+      {% comment %} Determine the category type for styling {% endcomment %}
+      {% if post.categories contains 'events' %}
+        {% assign post_type = 'event' %}
+        {% assign type_label = 'Event' %}
+      {% elsif post.categories contains 'rides' %}
+        {% assign post_type = 'ride' %}
+        {% assign type_label = 'Ride' %}
+      {% elsif post.categories contains 'volunteers' %}
+        {% assign post_type = 'volunteer' %}
+        {% assign type_label = 'Volunteer' %}
+      {% else %}
+        {% assign post_type = 'other' %}
+        {% assign type_label = 'Post' %}
+      {% endif %}
+
+      <div class="calendar-item calendar-{{ post_type }}">
+        <a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">
+          <div class="calendar-date">
+            <span class="calendar-day">{{ post_day }}</span>
+            <span class="calendar-weekday">{{ post.date | date: '%a' }}</span>
+          </div>
+          <div class="calendar-content">
+            {% if post.image.thumb %}
+              <div class="calendar-thumb">
+                <img src="{{ site.urlimg }}{{ post.image.thumb }}" alt="{{ post.title | escape }}">
+              </div>
+            {% endif %}
+            <div class="calendar-info">
+              <span class="calendar-type-badge calendar-badge-{{ post_type }}">{{ type_label }}</span>
+              <h4 class="calendar-title">{{ post.title }}</h4>
+              {% if post.event.when %}
+                <p class="calendar-when">{{ post.event.when }}</p>
+              {% elsif post.ride.when %}
+                <p class="calendar-when">{{ post.ride.when }}</p>
+              {% elsif post.volunteer.when %}
+                <p class="calendar-when">{{ post.volunteer.when }}</p>
+              {% endif %}
+              {% if post.teaser %}
+                <p class="calendar-teaser">{{ post.teaser }}</p>
+              {% endif %}
+            </div>
+          </div>
+        </a>
+      </div>
+    {% endfor %}
+
+    {% if displayed_months != "" %}
+      </div><!-- /.calendar-grid -->
+    {% endif %}
+  {% else %}
+    <p class="calendar-empty">No upcoming events, rides, or volunteer opportunities scheduled. Check back soon!</p>
+  {% endif %}
+
+  {% comment %} Past Events Section {% endcomment %}
+  {% if past_posts.size > 0 %}
+    <h2 class="calendar-section-header calendar-past-header">Past Events</h2>
+
+    {% assign displayed_months = "" %}
+
+    {% for post in past_posts %}
+      {% assign post_month_key = post.date | date: '%Y-%m' %}
+      {% assign post_day = post.date | date: '%-d' %}
+
+      {% comment %} Check if we need a new month header {% endcomment %}
+      {% unless displayed_months contains post_month_key %}
+        {% if displayed_months != "" %}
+          </div><!-- /.calendar-grid -->
+        {% endif %}
+
+        <h3 class="calendar-month-header">{{ post.date | date: '%B %Y' }}</h3>
+        <div class="calendar-grid">
+
+        {% capture displayed_months %}{{ displayed_months }}{{ post_month_key }},{% endcapture %}
+      {% endunless %}
+
+      {% comment %} Determine the category type for styling {% endcomment %}
+      {% if post.categories contains 'events' %}
+        {% assign post_type = 'event' %}
+        {% assign type_label = 'Event' %}
+      {% elsif post.categories contains 'rides' %}
+        {% assign post_type = 'ride' %}
+        {% assign type_label = 'Ride' %}
+      {% elsif post.categories contains 'volunteers' %}
+        {% assign post_type = 'volunteer' %}
+        {% assign type_label = 'Volunteer' %}
+      {% else %}
+        {% assign post_type = 'other' %}
+        {% assign type_label = 'Post' %}
+      {% endif %}
+
+      <div class="calendar-item calendar-{{ post_type }} calendar-past">
+        <a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">
+          <div class="calendar-date">
+            <span class="calendar-day">{{ post_day }}</span>
+            <span class="calendar-weekday">{{ post.date | date: '%a' }}</span>
+          </div>
+          <div class="calendar-content">
+            {% if post.image.thumb %}
+              <div class="calendar-thumb">
+                <img src="{{ site.urlimg }}{{ post.image.thumb }}" alt="{{ post.title | escape }}">
+              </div>
+            {% endif %}
+            <div class="calendar-info">
+              <span class="calendar-type-badge calendar-badge-{{ post_type }}">{{ type_label }}</span>
+              <h4 class="calendar-title">{{ post.title }}</h4>
+              {% if post.event.when %}
+                <p class="calendar-when">{{ post.event.when }}</p>
+              {% elsif post.ride.when %}
+                <p class="calendar-when">{{ post.ride.when }}</p>
+              {% elsif post.volunteer.when %}
+                <p class="calendar-when">{{ post.volunteer.when }}</p>
+              {% endif %}
+              {% if post.teaser %}
+                <p class="calendar-teaser">{{ post.teaser }}</p>
+              {% endif %}
+            </div>
+          </div>
+        </a>
+      </div>
+    {% endfor %}
+
+    {% if displayed_months != "" %}
+      </div><!-- /.calendar-grid -->
+    {% endif %}
+  {% endif %}
+
+  {% if upcoming_posts.size == 0 and past_posts.size == 0 %}
+    <p class="calendar-empty">No events, rides, or volunteer opportunities found.</p>
+  {% endif %}
+</div>

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -1,0 +1,4 @@
+---
+layout: page-fullwidth
+---
+{% include _calendar.html %}

--- a/_sass/_12_calendar.scss
+++ b/_sass/_12_calendar.scss
@@ -1,0 +1,257 @@
+@charset "utf-8";
+/* Calendar Styles
+------------------------------------------------------------------- */
+
+.calendar-container {
+  padding: 20px 0;
+}
+
+.calendar-section-header {
+  font-size: rem-calc(24);
+  color: $ci-2;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  margin: 0 0 20px 0;
+  padding-bottom: 10px;
+  border-bottom: 3px solid $ci-2;
+}
+
+.calendar-past-header {
+  color: $grey-6;
+  border-bottom-color: $grey-4;
+  margin-top: 50px;
+}
+
+.calendar-month-header {
+  font-size: rem-calc(28);
+  color: $primary-color;
+  border-bottom: 2px solid $ci-2;
+  padding-bottom: 10px;
+  margin: 30px 0 20px 0;
+
+  &:first-child {
+    margin-top: 0;
+  }
+}
+
+.calendar-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.calendar-item {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  border-left: 4px solid $grey-4;
+
+  &:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    transform: translateY(-2px);
+  }
+
+  a {
+    display: flex;
+    flex-direction: row;
+    text-decoration: none;
+    color: $text-color;
+  }
+}
+
+/* Category-specific border colors */
+.calendar-event {
+  border-left-color: $ci-2; // turquoise for events
+}
+
+.calendar-ride {
+  border-left-color: $ci-6; // green for rides
+}
+
+.calendar-volunteer {
+  border-left-color: $ci-4; // orange for volunteers
+}
+
+.calendar-date {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 70px;
+  padding: 15px;
+  background: $grey-1;
+  text-align: center;
+}
+
+.calendar-day {
+  font-size: rem-calc(32);
+  font-weight: bold;
+  color: $primary-color;
+  line-height: 1;
+}
+
+.calendar-weekday {
+  font-size: rem-calc(14);
+  color: $grey-8;
+  text-transform: uppercase;
+  margin-top: 5px;
+}
+
+.calendar-content {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  padding: 15px;
+  gap: 15px;
+  align-items: flex-start;
+}
+
+.calendar-thumb {
+  flex-shrink: 0;
+  width: 80px;
+  height: 80px;
+  overflow: hidden;
+  border-radius: 4px;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.calendar-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.calendar-type-badge {
+  display: inline-block;
+  font-size: rem-calc(11);
+  font-weight: bold;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 3px;
+  margin-bottom: 5px;
+}
+
+.calendar-badge-event {
+  background: $ci-2;
+  color: #fff;
+}
+
+.calendar-badge-ride {
+  background: $ci-6;
+  color: #fff;
+}
+
+.calendar-badge-volunteer {
+  background: $ci-4;
+  color: #fff;
+}
+
+.calendar-title {
+  font-size: rem-calc(18);
+  margin: 0 0 5px 0;
+  color: $primary-color;
+  line-height: 1.3;
+}
+
+.calendar-when {
+  font-size: rem-calc(13);
+  color: $grey-8;
+  margin: 0 0 5px 0;
+}
+
+.calendar-teaser {
+  font-size: rem-calc(14);
+  color: $grey-10;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.calendar-empty {
+  text-align: center;
+  padding: 40px;
+  color: $grey-6;
+  font-style: italic;
+}
+
+/* Past events styling */
+.calendar-past {
+  opacity: 0.7;
+  border-left-color: $grey-4 !important;
+
+  .calendar-date {
+    background: $grey-2;
+  }
+
+  .calendar-day {
+    color: $grey-8;
+  }
+
+  .calendar-title {
+    color: $grey-8;
+  }
+
+  .calendar-thumb img {
+    filter: grayscale(30%);
+  }
+
+  &:hover {
+    opacity: 1;
+
+    .calendar-thumb img {
+      filter: grayscale(0%);
+    }
+  }
+}
+
+/* Responsive adjustments */
+@media #{$small-only} {
+  .calendar-item a {
+    flex-direction: column;
+  }
+
+  .calendar-date {
+    flex-direction: row;
+    min-width: auto;
+    width: 100%;
+    justify-content: flex-start;
+    gap: 10px;
+    padding: 10px 15px;
+  }
+
+  .calendar-day {
+    font-size: rem-calc(24);
+  }
+
+  .calendar-weekday {
+    margin-top: 0;
+  }
+
+  .calendar-content {
+    flex-direction: column;
+  }
+
+  .calendar-thumb {
+    width: 100%;
+    height: 150px;
+  }
+}
+
+@media #{$medium-up} {
+  .calendar-thumb {
+    width: 100px;
+    height: 100px;
+  }
+}
+
+@media #{$large-up} {
+  .calendar-thumb {
+    width: 120px;
+    height: 120px;
+  }
+}

--- a/assets/css/styles_feeling_responsive.scss
+++ b/assets/css/styles_feeling_responsive.scss
@@ -47,3 +47,4 @@ sitemap:
 {% endif %}
 
 @import "11_syntax-highlighting.scss";
+@import "12_calendar.scss";

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -1,0 +1,8 @@
+---
+layout: calendar
+title: "Calendar"
+teaser: "Upcoming events, rides, and volunteer opportunities"
+header:
+    image_fullwidth: "singletrack_plains_header.png"
+breadcrumb: true
+---


### PR DESCRIPTION
## Summary
- Add a new calendar page that dynamically displays upcoming and past events, rides, and volunteer opportunities
- Calendar is accessible at `/calendar/` and linked in the main navigation

## Features
- Groups posts by month with clear section headers
- Shows "Upcoming" events first, then "Past Events" section
- Displays thumbnail images for each item
- Color-coded type badges:
  - Turquoise for Events
  - Green for Rides
  - Orange for Volunteers
- Each item shows date, day of week, title, time details, and teaser
- Past events styled with muted appearance (reduced opacity, grayscale thumbnails)
- Fully responsive layout for mobile devices
- Links directly to individual event/ride/volunteer pages

## Files Added
- `_includes/_calendar.html` - Liquid template for calendar logic
- `_layouts/calendar.html` - Page layout
- `calendar/index.html` - Calendar page
- `_sass/_12_calendar.scss` - Calendar styling

## Files Modified
- `_data/navigation.yml` - Added Calendar nav link
- `assets/css/styles_feeling_responsive.scss` - Import calendar styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)