### PR TITLE
Add MTRA Winter Meeting 2026 event

### DIFF
--- a/_posts/events/2026-01-14-mtra-meeting-winter-2026.md
+++ b/_posts/events/2026-01-14-mtra-meeting-winter-2026.md
@@ -1,0 +1,24 @@
+---
+layout: event
+sidebar: right
+subheadline: Meeting
+title:  "MTRA Winter Meeting"
+teaser: "MTRA's quarterly meeting."
+breadcrumb: true
+tags:
+    - meeting
+categories:
+    - events
+show_meta: false
+image:
+    thumb: mtra_winter_mtg-300x225.jpg
+    homepage: mtra_winter_mtg-1024x768.jpg
+    title: mtra_winter_mtg-1024x768.jpg
+event:
+    when: 6pm Jan 14th, 2026
+    where: Warehouse 2565
+    what: MTRA Meeting
+    who: Everyone is welcome!
+    directions: https://www.google.com/maps/search/?api=1&query=Warehouse+2565+Grand+Junction+CO
+---
+To keep the wheels rolling, and get everyone excited for the new riding season, we will be holding our first General Club Meeting for 2026 on Jan 14th, at Warehouse 2565, 6pm in the back room.  We'll provide a summary of the 2025 season, ask for your inputs on how to improve the Trail rides and Work days for 2026, and hold elections for Club Officers for 2026.  Hope to see you there, and bring all your friends and families - everyone is welcome!


### PR DESCRIPTION
## Summary
- Add new event post for the MTRA Winter Meeting on January 14th, 2026

## Event Details
- **When:** 6pm Jan 14th, 2026
- **Where:** Warehouse 2565
- **What:** MTRA Meeting (quarterly meeting, 2025 recap, 2026 planning, officer elections)
- **Who:** Everyone is welcome!

## Files Added
- `_posts/events/2026-01-14-mtra-meeting-winter-2026.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)