### PR TITLE
Add GitHub Actions for PR testing and nightly rebuilds

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -14,6 +14,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Allows this workflow to be called by other workflows
+  workflow_call:
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/.github/workflows/nightly-rebuild.yml
+++ b/.github/workflows/nightly-rebuild.yml
@@ -1,0 +1,15 @@
+name: Nightly Site Rebuild
+
+on:
+  schedule:
+    # 9:00 PM Mountain Standard Time (MST) = 4:00 AM UTC
+    # Note: During daylight saving time (MDT), this runs at 10:00 PM local time
+    - cron: '0 4 * * *'
+
+jobs:
+  rebuild:
+    uses: ./.github/workflows/jekyll.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -1,0 +1,23 @@
+name: Test Jekyll Build
+
+on:
+  pull_request:
+    branches: ["gh-pages"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "/mtragj"
+        env:
+          JEKYLL_ENV: production


### PR DESCRIPTION
## Summary
- Add workflow to test Jekyll builds on pull requests
- Add nightly rebuild workflow that triggers site deployment at 9 PM Mountain Time
- Make jekyll.yml reusable via workflow_call

## Test plan
- [ ] Verify PR build test workflow runs on this PR
- [ ] Merge and confirm nightly workflow appears in Actions tab
- [ ] Optionally trigger nightly-rebuild manually to verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)