### PR TITLE
Include date in permalinks to prevent filename conflicts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,7 +67,7 @@ paginate_path: "blog/page:num"   # Pagination path › Important for blog page i
 
 # Theme works best with Kramdown (using the table of contents function)
 markdown           : kramdown
-permalink          : /:categories/:title/
+permalink          : /:categories/:year/:month/:day/:title/
 highlight          : rouge
 excerpt_separator  : "<!--more-->"
 include            : ['.htaccess']


### PR DESCRIPTION
## Summary
- Change permalink format from `/:categories/:title/` to `/:categories/:year/:month/:day/:title/`
- Prevents conflicts when posts have the same name on different dates (e.g., annual "MTRA Winter Meeting" events)

## Test plan
- [x] Verified Jekyll build succeeds without conflicts
- [ ] Verify existing links are updated appropriately after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)