### PR TITLE
Add GitHub issue templates for content creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General Questions
+    url: https://mtragj.github.io/mtragj/contact/
+    about: For general questions, use the contact form on the website.

--- a/.github/ISSUE_TEMPLATE/event.yml
+++ b/.github/ISSUE_TEMPLATE/event.yml
@@ -1,0 +1,105 @@
+name: Event
+description: Create an MTRA event or meeting post
+title: "[Event] "
+labels: ["content", "event"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## New Event Post
+        Fill out the details below to create a new event post for the MTRA website.
+
+  - type: input
+    id: title
+    attributes:
+      label: Event Title
+      description: The main title for the event
+      placeholder: "MTRA Summer Meeting 2026"
+    validations:
+      required: true
+
+  - type: input
+    id: subheadline
+    attributes:
+      label: Subheadline
+      description: Short descriptor shown above the title
+      placeholder: "Meeting"
+    validations:
+      required: true
+
+  - type: textarea
+    id: teaser
+    attributes:
+      label: Teaser
+      description: Brief description of the event (1-2 sentences)
+      placeholder: "Join us for our quarterly meeting to discuss upcoming rides and trail projects."
+    validations:
+      required: true
+
+  - type: input
+    id: when
+    attributes:
+      label: When
+      description: Date and time of the event
+      placeholder: "6pm July 31st, 2026"
+    validations:
+      required: true
+
+  - type: input
+    id: where
+    attributes:
+      label: Where
+      description: Location name
+      placeholder: "Edgewater Brewery"
+    validations:
+      required: true
+
+  - type: input
+    id: what
+    attributes:
+      label: What
+      description: Type of event
+      placeholder: "MTRA Meeting"
+    validations:
+      required: true
+
+  - type: input
+    id: who
+    attributes:
+      label: Who
+      description: Who should attend
+      placeholder: "MTRA members, prospective members"
+    validations:
+      required: true
+
+  - type: input
+    id: directions
+    attributes:
+      label: Directions Link
+      description: Google Maps or other directions URL
+      placeholder: "https://maps.app.goo.gl/..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: body_content
+    attributes:
+      label: Event Details
+      description: Additional content for the event post (markdown supported)
+      placeholder: |
+        Add any additional details about the event here...
+
+        - Agenda items
+        - Special guests
+        - What to bring
+    validations:
+      required: false
+
+  - type: textarea
+    id: image
+    attributes:
+      label: Event Image
+      description: Drag and drop or paste an image here. This will be resized to thumbnail (300x225) and full size (1024x768).
+      placeholder: "Drag and drop an image here..."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/news.yml
+++ b/.github/ISSUE_TEMPLATE/news.yml
@@ -1,0 +1,62 @@
+name: News Post
+description: Create an MTRA news or announcement post
+title: "[News] "
+labels: ["content", "news"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## New News Post
+        Fill out the details below to create a new news post or announcement for the MTRA website.
+
+  - type: input
+    id: title
+    attributes:
+      label: Post Title
+      description: The main title for the news post
+      placeholder: "MTRA Receives Trail Grant"
+    validations:
+      required: true
+
+  - type: input
+    id: subheadline
+    attributes:
+      label: Subheadline
+      description: Short descriptor shown above the title
+      placeholder: "Announcement"
+    validations:
+      required: true
+
+  - type: textarea
+    id: teaser
+    attributes:
+      label: Teaser
+      description: Brief summary for listings and previews (1-2 sentences)
+      placeholder: "Exciting news about our latest trail project funding."
+    validations:
+      required: true
+
+  - type: textarea
+    id: body_content
+    attributes:
+      label: Post Content
+      description: The main content of the news post (markdown supported)
+      placeholder: |
+        Write your news post content here...
+
+        You can use markdown formatting:
+        - **Bold text**
+        - *Italic text*
+        - [Links](https://example.com)
+        - Lists and headers
+    validations:
+      required: true
+
+  - type: textarea
+    id: image
+    attributes:
+      label: Post Image
+      description: Drag and drop or paste an image here. This will be resized to thumbnail (300x225) and full size (1024x768).
+      placeholder: "Drag and drop an image here..."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/ride.yml
+++ b/.github/ISSUE_TEMPLATE/ride.yml
@@ -1,0 +1,141 @@
+name: Ride
+description: Create an MTRA group ride post
+title: "[Ride] "
+labels: ["content", "ride"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## New Ride Post
+        Fill out the details below to create a new group ride post for the MTRA website.
+
+  - type: input
+    id: title
+    attributes:
+      label: Ride Title
+      description: The main title for the ride
+      placeholder: "18 Road Ride"
+    validations:
+      required: true
+
+  - type: input
+    id: subheadline
+    attributes:
+      label: Subheadline
+      description: Short descriptor shown above the title
+      placeholder: "Moto Meetup"
+    validations:
+      required: true
+
+  - type: textarea
+    id: teaser
+    attributes:
+      label: Teaser
+      description: Brief description of the ride (1-2 sentences)
+      placeholder: "Join us for a fun day exploring the trails at 18 Road."
+    validations:
+      required: true
+
+  - type: input
+    id: when
+    attributes:
+      label: When
+      description: Date and time of the ride
+      placeholder: "10am May 25th, 2026"
+    validations:
+      required: true
+
+  - type: input
+    id: where
+    attributes:
+      label: Where
+      description: Meeting location
+      placeholder: "18 Rd OHV Parking Area"
+    validations:
+      required: true
+
+  - type: input
+    id: leader
+    attributes:
+      label: Ride Leader
+      description: Who is leading this ride
+      placeholder: "Dave Clapp"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty
+      description: Overall difficulty level
+      options:
+        - Beginner
+        - Beginner-Intermediate
+        - Intermediate
+        - Intermediate-Advanced
+        - Advanced
+    validations:
+      required: true
+
+  - type: input
+    id: distance
+    attributes:
+      label: Distance
+      description: Approximate ride distance
+      placeholder: "30-40 Miles"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: pace
+    attributes:
+      label: Pace
+      description: Expected riding pace
+      options:
+        - Easy
+        - Moderate
+        - Fast
+        - Varied
+    validations:
+      required: true
+
+  - type: input
+    id: terrain
+    attributes:
+      label: Terrain
+      description: Description of terrain types
+      placeholder: "Single-track, hills, gullies, varied"
+    validations:
+      required: true
+
+  - type: input
+    id: directions
+    attributes:
+      label: Directions Link
+      description: Google Maps or other directions URL
+      placeholder: "https://maps.app.goo.gl/..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: body_content
+    attributes:
+      label: Ride Details
+      description: Additional content for the ride post (markdown supported)
+      placeholder: |
+        Add any additional details about the ride here...
+
+        - What to bring
+        - Special considerations
+        - Route highlights
+    validations:
+      required: false
+
+  - type: textarea
+    id: image
+    attributes:
+      label: Ride Image
+      description: Drag and drop or paste an image here. This will be resized to thumbnail (300x225) and full size (1024x768).
+      placeholder: "Drag and drop an image here..."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/volunteer.yml
+++ b/.github/ISSUE_TEMPLATE/volunteer.yml
@@ -1,0 +1,127 @@
+name: Volunteer
+description: Create an MTRA volunteer opportunity post
+title: "[Volunteer] "
+labels: ["content", "volunteer"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## New Volunteer Opportunity Post
+        Fill out the details below to create a new volunteer/trail maintenance post for the MTRA website.
+
+  - type: input
+    id: title
+    attributes:
+      label: Title
+      description: The main title for the volunteer opportunity
+      placeholder: "North Unc Trail Maintenance"
+    validations:
+      required: true
+
+  - type: input
+    id: subheadline
+    attributes:
+      label: Subheadline
+      description: Short descriptor shown above the title
+      placeholder: "Volunteer Opportunity"
+    validations:
+      required: true
+
+  - type: textarea
+    id: teaser
+    attributes:
+      label: Teaser
+      description: Brief description of the volunteer opportunity (1-2 sentences)
+      placeholder: "Help us maintain the trails and keep them rideable for everyone."
+    validations:
+      required: true
+
+  - type: input
+    id: when
+    attributes:
+      label: When
+      description: Date and time
+      placeholder: "9am Aug 10th, 2026"
+    validations:
+      required: true
+
+  - type: input
+    id: where
+    attributes:
+      label: Where
+      description: Meeting location
+      placeholder: "North Unc Trailhead"
+    validations:
+      required: true
+
+  - type: input
+    id: leader
+    attributes:
+      label: Work Leader
+      description: Who is leading this volunteer effort
+      placeholder: "Chris Vestal"
+    validations:
+      required: true
+
+  - type: input
+    id: work
+    attributes:
+      label: Work Description
+      description: What type of work will be done
+      placeholder: "Building trail bridges"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: access
+    attributes:
+      label: Access
+      description: How to access the work site
+      options:
+        - Drive In
+        - Ride In
+        - Hike In
+        - Shuttle Provided
+    validations:
+      required: true
+
+  - type: input
+    id: bring
+    attributes:
+      label: What to Bring
+      description: Tools or supplies volunteers should bring
+      placeholder: "Hand saws, loppers, battery powered trimmer"
+    validations:
+      required: false
+
+  - type: input
+    id: directions
+    attributes:
+      label: Directions Link
+      description: Google Maps or other directions URL
+      placeholder: "https://maps.app.goo.gl/..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: body_content
+    attributes:
+      label: Additional Details
+      description: Additional content for the volunteer post (markdown supported)
+      placeholder: |
+        Add any additional details here...
+
+        - Specific tasks
+        - Lunch/refreshments provided?
+        - Expected duration
+    validations:
+      required: false
+
+  - type: textarea
+    id: image
+    attributes:
+      label: Volunteer Image
+      description: Drag and drop or paste an image here. This will be resized to thumbnail (300x225) and full size (1024x768).
+      placeholder: "Drag and drop an image here..."
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- Add structured issue templates for creating events, rides, volunteers, and news posts
- Each template includes form fields matching Jekyll front matter requirements
- Templates include image upload field for processing into thumbnail (300x225) and full-size (1024x768) versions
- Disable blank issues and add contact link for general questions

## Test plan
- [ ] Create a test issue using each template to verify form fields render correctly
- [ ] Verify image drag-and-drop works in the textarea fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)