### PR TITLE
Add embedded Google Maps to ride, event, and volunteer pages

### DIFF
--- a/_includes/_sidebar_event.html
+++ b/_includes/_sidebar_event.html
@@ -10,17 +10,17 @@
 	</div>
 
 	{% if page.event.directions %}
-	{% comment %}Extract coordinates from full Google Maps URLs, or fall back to where field{% endcomment %}
 	{% if page.event.directions contains '/@' %}
 		{% assign coords_part = page.event.directions | split: '/@' | last | split: '/' | first %}
-		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
-		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
 	{% elsif page.event.directions contains '/search/' %}
 		{% assign coords_part = page.event.directions | split: '/search/' | last | split: '?' | first %}
-		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
-		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
 	{% else %}
-		{% assign map_query = page.event.where | url_encode %}
+		{% assign coords_part = page.event.where %}
+	{% endif %}
+	{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
+	{% assign map_query = coords_array[0] | default: coords_part %}
+	{% if coords_array.size > 1 %}
+		{% assign map_query = coords_array[0] | append: ',' | append: coords_array[1] %}
 	{% endif %}
 	<div class="b30">
 		<iframe

--- a/_includes/_sidebar_event.html
+++ b/_includes/_sidebar_event.html
@@ -30,7 +30,7 @@
 			loading="lazy"
 			allowfullscreen
 			referrerpolicy="no-referrer-when-downgrade"
-			src="https://www.google.com/maps/embed/v1/place?key=YOUR_GOOGLE_MAPS_API_KEY&q={{ map_query }}&zoom=14">
+			src="https://www.google.com/maps/embed/v1/place?key=AIzaSyDQCDC7v-pRLTW4HIGl6wCEt8yGFaDEOXo&q={{ map_query }}&zoom=14">
 		</iframe>
 	</div>
 	{% endif %}

--- a/_includes/_sidebar_event.html
+++ b/_includes/_sidebar_event.html
@@ -9,7 +9,31 @@
 		</ul>
 	</div>
 
-  <!-- <img class="b30" src="http://dummyimage.com/303x16:9/df4949/e27b3f.png&amp;text=Ugly+Ad+Space" alt=""> -->
+	{% if page.event.directions %}
+	{% comment %}Extract coordinates from full Google Maps URLs, or fall back to where field{% endcomment %}
+	{% if page.event.directions contains '/@' %}
+		{% assign coords_part = page.event.directions | split: '/@' | last | split: '/' | first %}
+		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
+		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
+	{% elsif page.event.directions contains '/search/' %}
+		{% assign coords_part = page.event.directions | split: '/search/' | last | split: '?' | first %}
+		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
+		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
+	{% else %}
+		{% assign map_query = page.event.where | url_encode %}
+	{% endif %}
+	<div class="b30">
+		<iframe
+			width="300"
+			height="300"
+			style="border:0; border-radius:3px;"
+			loading="lazy"
+			allowfullscreen
+			referrerpolicy="no-referrer-when-downgrade"
+			src="https://www.google.com/maps/embed/v1/place?key=YOUR_GOOGLE_MAPS_API_KEY&q={{ map_query }}&zoom=14">
+		</iframe>
+	</div>
+	{% endif %}
 
 
 	<div class="border-dotted radius b30">

--- a/_includes/_sidebar_ride.html
+++ b/_includes/_sidebar_ride.html
@@ -12,6 +12,32 @@
 		</ul>
 	</div>
 
+	{% if page.ride.directions %}
+	{% comment %}Extract coordinates from full Google Maps URLs, or fall back to where field{% endcomment %}
+	{% if page.ride.directions contains '/@' %}
+		{% assign coords_part = page.ride.directions | split: '/@' | last | split: '/' | first %}
+		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
+		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
+	{% elsif page.ride.directions contains '/search/' %}
+		{% assign coords_part = page.ride.directions | split: '/search/' | last | split: '?' | first %}
+		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
+		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
+	{% else %}
+		{% assign map_query = page.ride.where | url_encode %}
+	{% endif %}
+	<div class="b30">
+		<iframe
+			width="300"
+			height="300"
+			style="border:0; border-radius:3px;"
+			loading="lazy"
+			allowfullscreen
+			referrerpolicy="no-referrer-when-downgrade"
+			src="https://www.google.com/maps/embed/v1/place?key=YOUR_GOOGLE_MAPS_API_KEY&q={{ map_query }}&zoom=14">
+		</iframe>
+	</div>
+	{% endif %}
+
   <img class="b30" src="{{ site.urlimg }}/mtra-motomeetup_612x792.jpg" alt="">
 
 

--- a/_includes/_sidebar_ride.html
+++ b/_includes/_sidebar_ride.html
@@ -13,17 +13,17 @@
 	</div>
 
 	{% if page.ride.directions %}
-	{% comment %}Extract coordinates from full Google Maps URLs, or fall back to where field{% endcomment %}
 	{% if page.ride.directions contains '/@' %}
 		{% assign coords_part = page.ride.directions | split: '/@' | last | split: '/' | first %}
-		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
-		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
 	{% elsif page.ride.directions contains '/search/' %}
 		{% assign coords_part = page.ride.directions | split: '/search/' | last | split: '?' | first %}
-		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
-		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
 	{% else %}
-		{% assign map_query = page.ride.where | url_encode %}
+		{% assign coords_part = page.ride.where %}
+	{% endif %}
+	{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
+	{% assign map_query = coords_array[0] | default: coords_part %}
+	{% if coords_array.size > 1 %}
+		{% assign map_query = coords_array[0] | append: ',' | append: coords_array[1] %}
 	{% endif %}
 	<div class="b30">
 		<iframe

--- a/_includes/_sidebar_ride.html
+++ b/_includes/_sidebar_ride.html
@@ -33,7 +33,7 @@
 			loading="lazy"
 			allowfullscreen
 			referrerpolicy="no-referrer-when-downgrade"
-			src="https://www.google.com/maps/embed/v1/place?key=YOUR_GOOGLE_MAPS_API_KEY&q={{ map_query }}&zoom=14">
+			src="https://www.google.com/maps/embed/v1/place?key=AIzaSyDQCDC7v-pRLTW4HIGl6wCEt8yGFaDEOXo&q={{ map_query }}&zoom=14">
 		</iframe>
 	</div>
 	{% endif %}

--- a/_includes/_sidebar_volunteer.html
+++ b/_includes/_sidebar_volunteer.html
@@ -11,7 +11,31 @@
 		</ul>
 	</div>
 
-  <!-- <img class="b30" src="{{ site.urlimg }}/mtra-motomeetup_612x792.jpg" alt=""> -->
+	{% if page.volunteer.directions %}
+	{% comment %}Extract coordinates from full Google Maps URLs, or fall back to where field{% endcomment %}
+	{% if page.volunteer.directions contains '/@' %}
+		{% assign coords_part = page.volunteer.directions | split: '/@' | last | split: '/' | first %}
+		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
+		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
+	{% elsif page.volunteer.directions contains '/search/' %}
+		{% assign coords_part = page.volunteer.directions | split: '/search/' | last | split: '?' | first %}
+		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
+		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
+	{% else %}
+		{% assign map_query = page.volunteer.where | url_encode %}
+	{% endif %}
+	<div class="b30">
+		<iframe
+			width="300"
+			height="300"
+			style="border:0; border-radius:3px;"
+			loading="lazy"
+			allowfullscreen
+			referrerpolicy="no-referrer-when-downgrade"
+			src="https://www.google.com/maps/embed/v1/place?key=YOUR_GOOGLE_MAPS_API_KEY&q={{ map_query }}&zoom=14">
+		</iframe>
+	</div>
+	{% endif %>
 
 
 	<div class="border-dotted radius b30">

--- a/_includes/_sidebar_volunteer.html
+++ b/_includes/_sidebar_volunteer.html
@@ -12,17 +12,17 @@
 	</div>
 
 	{% if page.volunteer.directions %}
-	{% comment %}Extract coordinates from full Google Maps URLs, or fall back to where field{% endcomment %}
 	{% if page.volunteer.directions contains '/@' %}
 		{% assign coords_part = page.volunteer.directions | split: '/@' | last | split: '/' | first %}
-		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
-		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
 	{% elsif page.volunteer.directions contains '/search/' %}
 		{% assign coords_part = page.volunteer.directions | split: '/search/' | last | split: '?' | first %}
-		{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
-		{% assign map_query = coords_array[0] | strip | append: ',' | append: coords_array[1] %}
 	{% else %}
-		{% assign map_query = page.volunteer.where | url_encode %}
+		{% assign coords_part = page.volunteer.where %}
+	{% endif %}
+	{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
+	{% assign map_query = coords_array[0] | default: coords_part %}
+	{% if coords_array.size > 1 %}
+		{% assign map_query = coords_array[0] | append: ',' | append: coords_array[1] %}
 	{% endif %}
 	<div class="b30">
 		<iframe
@@ -35,7 +35,7 @@
 			src="https://www.google.com/maps/embed/v1/place?key=AIzaSyDQCDC7v-pRLTW4HIGl6wCEt8yGFaDEOXo&q={{ map_query }}&zoom=14">
 		</iframe>
 	</div>
-	{% endif %>
+	{% endif %}
 
 
 	<div class="border-dotted radius b30">

--- a/_includes/_sidebar_volunteer.html
+++ b/_includes/_sidebar_volunteer.html
@@ -32,7 +32,7 @@
 			loading="lazy"
 			allowfullscreen
 			referrerpolicy="no-referrer-when-downgrade"
-			src="https://www.google.com/maps/embed/v1/place?key=YOUR_GOOGLE_MAPS_API_KEY&q={{ map_query }}&zoom=14">
+			src="https://www.google.com/maps/embed/v1/place?key=AIzaSyDQCDC7v-pRLTW4HIGl6wCEt8yGFaDEOXo&q={{ map_query }}&zoom=14">
 		</iframe>
 	</div>
 	{% endif %>


### PR DESCRIPTION
## Summary
- Adds an embedded Google Map to the sidebar on ride, event, and volunteer detail pages
- Map is positioned below the details box, sized at 300x300
- Extracts coordinates from full Google Maps URLs (`/@lat,lng` or `/search/lat,lng` format)
- Falls back to using the `where` field as a search query for short `goo.gl` URLs

## Test plan
- [ ] Verify map displays on ride detail pages (e.g., 18 Road Ride)
- [ ] Verify map displays on event detail pages (e.g., Summer Meeting)
- [ ] Verify map displays on volunteer detail pages (e.g., North Unc Trail Maintenance)
- [ ] Replace `YOUR_GOOGLE_MAPS_API_KEY` with actual API key in all three sidebar files

🤖 Generated with [Claude Code](https://claude.com/claude-code)