### PR TITLE
Feature next upcoming event on homepage

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -120,7 +120,7 @@ format: frontpage
         </div>
 
         <div class="medium-6 columns">
-            <p><strong>{{ site.data.language.more_articles }}</strong></p>
+            <p><strong>More Events</strong></p>
             <ul class="side-nav">
               {% for post in upcoming_posts limit:3 offset:1 %}
                 <li><a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">{% if post.subheadline %}{{ post.subheadline }} &middot; {% endif %}<strong>{{ post.title }}</strong></a></li>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -83,6 +83,10 @@ format: frontpage
 {% endfor %}
 {% assign upcoming_posts = upcoming_posts | reverse %}
 
+{% if upcoming_posts == empty %}
+  {% assign upcoming_posts = sorted_posts | slice: 0, 1 %}
+{% endif %}
+
 {% unless upcoming_posts == empty %}
     <div class="row t30 b20 homepage">
         <div class="small-12 columns">

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -71,15 +71,26 @@ format: frontpage
 *
 {% endcomment %}
 
-{% unless site.posts == empty %}
+{% assign all_posts = site.categories.events | concat: site.categories.rides | concat: site.categories.volunteers %}
+{% assign sorted_posts = all_posts | sort: 'date' | reverse %}
+{% assign today = 'now' | date: '%Y-%m-%d' %}
+{% assign upcoming_posts = "" | split: "" %}
+{% for post in sorted_posts %}
+  {% assign post_date = post.date | date: '%Y-%m-%d' %}
+  {% if post_date >= today %}
+    {% assign upcoming_posts = upcoming_posts | push: post %}
+  {% endif %}
+{% endfor %}
+{% assign upcoming_posts = upcoming_posts | reverse %}
+
+{% unless upcoming_posts == empty %}
     <div class="row t30 b20 homepage">
         <div class="small-12 columns">
-            {% for post in site.posts limit:1 %}
+            {% for post in upcoming_posts limit:1 %}
             {% if post.image.homepage %}
             <p>
                 <a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}" title="{{ post.title | escape_once }}"><img width="970" src="{{ site.urlimg }}{{ post.image.homepage }}" alt="{{ page.title | escape_once }}"></a>
             </p>
-
             {% if post.image.caption_url and post.image.caption %}
             <p class="text-right caption">
                 <a href="{{ post.image.caption_url }}">{{ post.image.caption }}</a>
@@ -89,13 +100,12 @@ format: frontpage
             <h2>{{ site.data.language.new_blog_entries }}</h2>
             {% endif %}
             {% endfor %}
-        </div><!-- /.small-12.columns -->
-    </div><!-- /.row -->
-
+        </div>
+    </div>
 
     <div class="row">
         <div class="medium-6 columns">
-            {% for post in site.posts limit:1 %}
+            {% for post in upcoming_posts limit:1 %}
             {% if post.subheadline %}<p class="subheadline">{{ post.subheadline }}</p>{% endif %}
             <h2><a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
             <p>
@@ -103,14 +113,18 @@ format: frontpage
                 <a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}" title="Read {{ post.title | escape_once }}"><strong>{{ site.data.language.read_more }}</strong></a>
             </p>
             {% endfor %}
-        </div><!-- /.medium-5.columns -->
-
+        </div>
 
         <div class="medium-6 columns">
             <p><strong>{{ site.data.language.more_articles }}</strong></p>
-            {% include list-posts entries='3' offset='1' %}
-        </div><!-- /.medium-7.columns -->
-    </div><!-- /.row -->
+            <ul class="side-nav">
+              {% for post in upcoming_posts limit:3 offset:1 %}
+                <li><a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">{% if post.subheadline %}{{ post.subheadline }} &middot; {% endif %}<strong>{{ post.title }}</strong></a></li>
+              {% endfor %}
+                <li class="text-right"><a href="{{ site.url }}{{ site.baseurl }}/calendar/"><strong>{{ site.data.language.more }}</strong></a></li>
+            </ul>
+        </div>
+    </div>
 {% endunless %}
 
 

--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -16,11 +16,11 @@ widget2:
   title: "Ride with Us!"
   url: 'https://grandvalleydirtbikerally.com'
   image: gvdbr_logo_271_168.png
-  text: '<b>October 16th - 18th, 2025</b><br> The Grand Valley Dirt Bike Rally will return in 2026, put on by the MTRA! We will be offering guided rides in 3 different areas with a variety of lengths and difficulties as well as an event area with exciting activities.'
+  text: '<b>October 16th - 18th, 2026</b><br> The Grand Valley Dirt Bike Rally will return in 2026, put on by the MTRA! We will be offering guided rides in 3 different areas with a variety of lengths and difficulties as well as an event area with exciting activities.'
 #   video: '<a href="#" data-reveal-id="videoModal"><img src="http://phlow.github.io/feeling-responsive/images/start-video-feeling-responsive-302x182.jpg" width="302" height="182" alt=""/></a>'
 widget3:
   title: "Ride with Us!"
-  url: '/rides/'
+  url: '/calendar/'
   image: mtra_motomeetup_270x323.jpg
   text: 'Come ride with us at regulary scheduled meetups where we''ll explore local trails and riding areas and provide the opportunity to meet other local riders.'
 #


### PR DESCRIPTION
## Summary
- Homepage now features the **next upcoming event** (by date) instead of the most recent post by publish date
- Combines events, rides, and volunteers categories and filters to future dates only — matching the calendar page logic
- "More articles" sidebar shows the next 3 upcoming events and links to the calendar page

## Test plan
- [ ] Run `bundle exec jekyll serve` and verify the homepage hero section shows the soonest future event
- [ ] Verify the "more articles" sidebar lists the next 3 upcoming events after the featured one
- [ ] Verify the "More" link goes to `/calendar/` instead of the blog archive
- [ ] Confirm site builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)