### PR TITLE
Add Google Analytics tracking ID

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -232,7 +232,7 @@ sass:
 #
 # used in _includes/footer_scripts
 
-# google_analytics_tracking_id:
+google_analytics_tracking_id: 'G-ZC7JGW9KR8'
 
 
 


### PR DESCRIPTION
## Summary
- Set `google_analytics_tracking_id` in `_config.yml` to `G-ZC7JGW9KR8` to enable site analytics

## Test plan
- [x] Verify site builds successfully on GitHub Pages after merge
- [ ] Confirm GA tag fires on the live site (Realtime view in Google Analytics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)