### PR TITLE
Fix Play button on /game/ splash page (404 under custom domain)

### DIFF
--- a/pages/game.md
+++ b/pages/game.md
@@ -6,9 +6,9 @@ teaser: "A low-poly 3D dirt bike riding game built by one of our members. Thrott
 permalink: "/game/"
 ---
 
-<a class="radius button" href="{{ site.baseurl }}/dirt-bike-game/">Play the Dirt Bike Game</a>
+<a class="radius button" href="{{ site.url }}{{ site.baseurl }}/dirt-bike-game/">Play the Dirt Bike Game</a>
 
-[![Dirt Bike Game screenshot]({{ site.urlimg }}dirt_bike_game.png)]({{ site.baseurl }}/dirt-bike-game/)
+[![Dirt Bike Game screenshot]({{ site.urlimg }}dirt_bike_game.png)]({{ site.url }}{{ site.baseurl }}/dirt-bike-game/)
 
 ## About
 


### PR DESCRIPTION
## Summary
Fixes the 404 from clicking "Play the Dirt Bike Game" on `mtragj.org/game/`.

The game itself deploys fine — the submodule checkout in the workflow works and `mtragj.org/dirt-bike-game/` returns 200. The bug was in how the splash page wrote its outbound link.

The site has `baseurl: /mtragj` configured but is served at the root of the `mtragj.org` custom domain. The rest of the site works around this by using `{{ site.url }}{{ site.baseurl }}` (full URL to `mtragj.github.io/mtragj/...`), which GitHub Pages 301-redirects to the custom domain. The splash page was using only `{{ site.baseurl }}`, producing the relative path `/mtragj/dirt-bike-game/` — which is a 404 under `mtragj.org`.

Updated both links on the splash page (Play button + screenshot link) to match the site-wide pattern.

## Test plan
- [ ] After deploy, `mtragj.org/game/` Play button leads to the live game
- [ ] Screenshot click on `/game/` also leads to the game
- [ ] Nav "Game" link still works (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)