### PR TITLE
Fix redirect layout target for apex custom domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,14 +166,28 @@ appears in `site.categories.*` listings or the calendar):
    ---
    ```
    - `permalink` and `redirect_to` are root-relative paths **without** the
-     baseurl; `_layouts/redirect.html` prepends `site.baseurl` automatically
-     (absolute `http(s)://` URLs are passed through as-is).
+     baseurl. `_layouts/redirect.html` prepends `site.url` + `site.baseurl` to
+     produce a full URL (`https://mtragj.github.io/mtragj/...`), matching how the
+     rest of the site links to posts. Absolute `http(s)://` URLs are passed
+     through as-is.
+   - **Why the full URL and not just a root-relative path:** the live site is
+     served at the apex domain root via custom domain (`mtragj.org`), but
+     `baseurl` is `/mtragj`. A root-relative `/mtragj/...` target 404s on the
+     apex (there's no `/mtragj/` prefix there), whereas the full
+     `github.io/mtragj/...` URL 301-redirects to the correct apex path. Do **not**
+     use the `relative_url` filter here — it only prepends baseurl and produces
+     the broken `/mtragj/...` form.
    - Add one stub per old URL. If a post's date changes more than once, chain or
      repoint stubs so every previously-shared URL still resolves.
-3. **Verify with a build** (`bundle exec jekyll build --config _config.yml,_config_dev.yml`):
-   the old URL's `index.html` should `<meta refresh>` to the new path, the new
-   URL should appear in the volunteer/calendar/frontpage listings, and the old
-   URL should appear in *neither* the listings nor `_site/sitemap.xml`.
+3. **Verify with a production build** (`bundle exec jekyll build --config _config.yml`):
+   the old URL's `index.html` should `<meta refresh>` to the *full*
+   `https://mtragj.github.io/mtragj/.../` target (identical to how a listing
+   links to the post — compare `_site/volunteer/index.html`). The new URL should
+   appear in the volunteer/calendar/frontpage listings, and the old URL should
+   appear in *neither* the listings nor `_site/sitemap.xml`. Optionally confirm
+   the target resolves live with
+   `curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" <target>`
+   (expect `301 -> https://mtragj.org/...`).
 
 ## Git Workflow
 

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -9,10 +9,15 @@
 # 
 # Idea and Code by: http://codingtips.kanishkkunal.in/about/
 #
-# An absolute URL (containing "://") is used as-is; a root-relative path
-# (e.g. /volunteers/...) has the site baseurl prepended automatically.
+# An absolute URL (containing "://") is used as-is. A root-relative path
+# (e.g. /volunteers/...) gets site.url + site.baseurl prepended, matching how
+# the rest of the site links to posts ({{ site.url }}{{ site.baseurl }}{{ post.url }}).
+# This is required because the site is served at the apex domain root via a
+# custom domain (mtragj.org), while baseurl is /mtragj: a root-relative
+# /mtragj/... path 404s on the apex, but the full github.io/mtragj/... URL
+# 301-redirects to the correct apex path the same way every other link does.
 ---
-{% if page.redirect_to contains '://' %}{% assign redirect_target = page.redirect_to %}{% else %}{% assign redirect_target = page.redirect_to | relative_url %}{% endif %}
+{% if page.redirect_to contains '://' %}{% assign redirect_target = page.redirect_to %}{% else %}{% assign redirect_target = page.redirect_to | prepend: site.baseurl | prepend: site.url %}{% endif %}
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
## Problem
The Upper Bench work-weekend redirect (added in #58) 404s on the live site. The old shared URL `https://mtragj.org/volunteers/2026/06/26/upper-bench-trail-work-weekend/` serves the redirect stub, but it forwards to `/mtragj/volunteers/2026/06/27/...`, which 404s.

## Root cause
The site is served at the **apex domain root** via custom domain (`mtragj.org`, CNAME), while Jekyll `baseurl` is `/mtragj`. The redirect layout used the `relative_url` filter, which prepends only baseurl, producing a root-relative `/mtragj/...` target. On the apex domain there is no `/mtragj/` prefix, so that path 404s.

The rest of the site avoids this by linking to the **full** `https://mtragj.github.io/mtragj/...` URL, which GitHub 301-redirects to the correct apex path.

## Fix
`_layouts/redirect.html` now prepends `site.url` + `site.baseurl` (matching `{{ site.url }}{{ site.baseurl }}{{ post.url }}` used throughout `_includes/`), instead of `relative_url`. Absolute `http(s)://` targets still pass through unchanged. CLAUDE.md updated with the rationale and the apex-domain gotcha.

## Verified (production build)
- Stub target is now `https://mtragj.github.io/mtragj/volunteers/2026/06/27/upper-bench-trail-work-weekend/` — identical to how a listing links to the post.
- That target resolves live: `301 -> https://mtragj.org/volunteers/2026/06/27/upper-bench-trail-work-weekend/` (200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)