### PR TITLE
Serve site from apex domain root (mtragj.org), drop /mtragj baseurl

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: General Questions
-    url: https://mtragj.github.io/mtragj/contact/
+    url: https://mtragj.org/contact/
     about: For general questions, use the contact form on the website.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ bundle install
 ### Configuration
 - `_config.yml`: Main production configuration
 - `_config_dev.yml`: Development overrides (merge with main config)
-- Site URL: `https://mtragj.github.io/mtragj`
+- Site URL: `https://mtragj.org` (custom apex domain via `CNAME`; served at root, so `baseurl` is empty)
 - Images base URL is configured in `urlimg` variable
 
 ### Content Organization
@@ -167,27 +167,21 @@ appears in `site.categories.*` listings or the calendar):
    ```
    - `permalink` and `redirect_to` are root-relative paths **without** the
      baseurl. `_layouts/redirect.html` prepends `site.url` + `site.baseurl` to
-     produce a full URL (`https://mtragj.github.io/mtragj/...`), matching how the
-     rest of the site links to posts. Absolute `http(s)://` URLs are passed
-     through as-is.
-   - **Why the full URL and not just a root-relative path:** the live site is
-     served at the apex domain root via custom domain (`mtragj.org`), but
-     `baseurl` is `/mtragj`. A root-relative `/mtragj/...` target 404s on the
-     apex (there's no `/mtragj/` prefix there), whereas the full
-     `github.io/mtragj/...` URL 301-redirects to the correct apex path. Do **not**
-     use the `relative_url` filter here — it only prepends baseurl and produces
-     the broken `/mtragj/...` form.
+     produce a full URL, matching how the rest of the site links to posts
+     (`{{ site.url }}{{ site.baseurl }}{{ post.url }}`). The site is served at the
+     apex domain root (`mtragj.org`) with an empty `baseurl`, so this yields a
+     direct `https://mtragj.org/...` target. Absolute `http(s)://` URLs are
+     passed through as-is.
    - Add one stub per old URL. If a post's date changes more than once, chain or
      repoint stubs so every previously-shared URL still resolves.
 3. **Verify with a production build** (`bundle exec jekyll build --config _config.yml`):
-   the old URL's `index.html` should `<meta refresh>` to the *full*
-   `https://mtragj.github.io/mtragj/.../` target (identical to how a listing
-   links to the post — compare `_site/volunteer/index.html`). The new URL should
-   appear in the volunteer/calendar/frontpage listings, and the old URL should
-   appear in *neither* the listings nor `_site/sitemap.xml`. Optionally confirm
-   the target resolves live with
-   `curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" <target>`
-   (expect `301 -> https://mtragj.org/...`).
+   the old URL's `index.html` should `<meta refresh>` to the full
+   `https://mtragj.org/.../` target (identical to how a listing links to the
+   post — compare `_site/volunteer/index.html`). The new URL should appear in the
+   volunteer/calendar/frontpage listings, and the old URL should appear in
+   *neither* the listings nor `_site/sitemap.xml`. Optionally confirm the target
+   resolves live with
+   `curl -s -o /dev/null -w "%{http_code}\n" https://mtragj.org/...` (expect 200).
 
 ## Git Workflow
 

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+mtragj.org

--- a/_config.yml
+++ b/_config.yml
@@ -25,8 +25,8 @@ author: phlow
 
 # This URL is the main address for absolute links. Don't include a slash at the end.
 #
-url: 'https://mtragj.github.io'
-baseurl: '/mtragj'
+url: 'https://mtragj.org'
+baseurl: ''
 
 # This is for the editing function in _/includes/improve_content
 # Leave it empty if your site is not on GitHub/GitHub Pages
@@ -38,8 +38,7 @@ improve_content: https://github.com/Phlow/feeling-responsive/edit/gh-pages
 # Example: <img src="{{ site.urlimg }}{{ post.image.title }}" />
 # Markdown-Example for posts ![Image Text]({{ site.urlimg }}image.jpg)
 #
-# urlimg: 'http://localhost:4000/mtragj/images/' # TODO revert url before publishing
-urlimg: 'https://mtragj.github.io/mtragj/images/' # TODO revert url before publishing
+urlimg: 'https://mtragj.org/images/'
 
 
 

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -5,9 +5,9 @@
 #
 # Start development with › $ jekyll serve --config _config.yml,_config_dev.yml
 
-url: 'http://localhost:4000/'
-baseurl: '/mtra'
-urlimg: 'http://localhost:4000/mtra/images/'
+url: 'http://localhost:4000'
+baseurl: ''
+urlimg: 'http://localhost:4000/images/'
 
 # See › https://github.com/jekyll/jekyll-gist#disabling-noscript-support
 gist:

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -12,10 +12,8 @@
 # An absolute URL (containing "://") is used as-is. A root-relative path
 # (e.g. /volunteers/...) gets site.url + site.baseurl prepended, matching how
 # the rest of the site links to posts ({{ site.url }}{{ site.baseurl }}{{ post.url }}).
-# This is required because the site is served at the apex domain root via a
-# custom domain (mtragj.org), while baseurl is /mtragj: a root-relative
-# /mtragj/... path 404s on the apex, but the full github.io/mtragj/... URL
-# 301-redirects to the correct apex path the same way every other link does.
+# The site is served at the apex domain root (mtragj.org) with an empty
+# baseurl, so this yields a direct https://mtragj.org/... target.
 ---
 {% if page.redirect_to contains '://' %}{% assign redirect_target = page.redirect_to %}{% else %}{% assign redirect_target = page.redirect_to | prepend: site.baseurl | prepend: site.url %}{% endif %}
 <!DOCTYPE html>


### PR DESCRIPTION
## Problem
The site is served at the apex custom domain root (`mtragj.org`, via CNAME), but Jekyll was configured with `url: https://mtragj.github.io` and `baseurl: /mtragj`. As a result, **every internal link and asset** was emitted as `https://mtragj.github.io/mtragj/...`, which only resolves because GitHub 301-redirects it to the apex. That's why links people copy/share come out as the ugly `github.io/mtragj/...` instead of `mtragj.org/...`, and it's the root cause of the redirect breakage fixed in #59.

## Change
- `_config.yml`: `url: https://mtragj.org`, `baseurl: ''`, `urlimg: https://mtragj.org/images/` (also removed a stale dev TODO on `urlimg`).
- `_config_dev.yml`: empty baseurl too, so local builds mirror production (served at `localhost:4000/` root).
- **Added `CNAME`** (`mtragj.org`) so the custom domain persists across deploys (it was only set in repo settings before).
- Fixed the hardcoded `github.io` contact link in `.github/ISSUE_TEMPLATE/config.yml`.
- Updated `_layouts/redirect.html` comment + CLAUDE.md to note that `site.url + site.baseurl` now yields a direct apex target (no github.io 301 hop), since #59's github.io rationale no longer applies.

No template logic changed — the existing `{{ site.url }}{{ site.baseurl }}{{ post.url }}` / `absolute_url` patterns now simply produce clean apex URLs.

## Verification (local prod + dev builds)
- **Prod build**: zero `mtragj.github.io` / `/mtragj/` references remain. Assets → `https://mtragj.org/assets/...`; post canonical → `https://mtragj.org/volunteers/.../`; moved-post redirect target → `https://mtragj.org/volunteers/2026/06/27/upper-bench-trail-work-weekend/`.
- Confirmed the apex already serves `/assets/...` and `/images/...` (200), so nothing 404s after the switch.
- **Dev build**: links resolve to `http://localhost:4000/...` root.

## Rollback
Isolated to config + CNAME + a couple of doc/template references. Reverting this PR restores the previous `github.io`/`/mtragj` behavior (the site keeps working either way via GitHub's 301). Worth a quick post-merge spot-check of the live site once Pages redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)