### PR TITLE
Fix prod: stop hardcoding --baseurl /mtragj in deploy workflow

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -49,9 +49,12 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
-        # run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
-        run: bundle exec jekyll build --baseurl "/mtragj" # Ugly hardcode, configure-pages action isn't outputting properly currently
+        # Outputs to the './_site' directory by default.
+        # The site is served at the apex custom domain root (mtragj.org), so the
+        # baseurl must be empty. Let _config.yml drive it (baseurl: '') rather
+        # than passing --baseurl, which previously hardcoded "/mtragj" and broke
+        # every link/asset on the apex domain (mtragj.org/mtragj/... -> 404).
+        run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
       - name: Upload artifact


### PR DESCRIPTION
## Problem (prod is broken)
After #60 moved the site to the apex domain root (`baseurl: ''`), the live site broke: CSS/assets fail to load and post links 404, all because URLs render as `https://mtragj.org/mtragj/...`.

## Root cause
`.github/workflows/jekyll.yml` built the site with a hardcoded CLI flag:
```
run: bundle exec jekyll build --baseurl "/mtragj"  # Ugly hardcode, configure-pages action isn't outputting properly currently
```
The `--baseurl` CLI flag **overrides `_config.yml`**, so my config change to `baseurl: ''` was ignored at deploy time and `/mtragj` got re-injected into every link and asset. (`url` still came from config = `mtragj.org`, hence `mtragj.org/mtragj/...`.) This is why local builds looked correct but production didn't.

## Fix
Drop the `--baseurl` override and let `_config.yml` drive the build (`baseurl: ''`).

## Verification
Reproduced the exact workflow build locally (`JEKYLL_ENV=production`, `bundle exec jekyll build`, `_config.yml` only):
- CSS → `https://mtragj.org/assets/css/styles_feeling_responsive.css`
- Ride links → `https://mtragj.org/rides/...`
- Zero `/mtragj/` or `github.io` references; `CNAME` preserved in `_site`.

## After merge
This triggers a Pages redeploy. Once it completes, the live site should serve clean apex URLs with working CSS and post links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)