### PR TITLE
Clarify membership button covers renewals

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -25,7 +25,7 @@ Motorcycle Trail Riding Association (MTRA) is a 501 ©  3 nonprofit organization
 MTRA strives to keep all public lands in Western Colorado open to responsible, respectful recreational usage by interactive cooperation with local, State and Federal agencies and other user groups.  Through a combination of volunteer labor, rider/public education and local involvement, MTRA works to advocate for, develop, build, and maintain dedicated single-track trails to ensure the continued success and growth of our sport.
 </p>
 
-<a class="radius button small" href="https://forms.gle/tA77sVKiLEMGxnZ76">Become a member of the MTRA</a>
+<a class="radius button small" href="https://forms.gle/tA77sVKiLEMGxnZ76">Join or Renew Your Membership</a>
 
  [1]: {{ site.url }}{{ site.baseurl }}/documentation/
 

--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -35,7 +35,7 @@ widget3:
 #
 callforaction:
   url: https://forms.gle/tA77sVKiLEMGxnZ76
-  text: Become a member of the MTRA ›
+  text: Join or Renew Your Membership ›
   style: alert
 permalink: /index.html
 #


### PR DESCRIPTION
## Summary
Updates the membership button on both the **home page** and **about page** so current members know it's also how they renew their annual membership.

- `pages/pages-root-folder/index.md` (home page call-to-action): `Become a member of the MTRA ›` → `Join or Renew Your Membership ›`
- `pages/about.md` (button): `Become a member of the MTRA` → `Join or Renew Your Membership`

Same form link, just clearer concise wording. Confirmed no other occurrences of the old text remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)